### PR TITLE
PLA-1049: Add Socket security scan workflow

### DIFF
--- a/.github/workflows/socket-scan.yml
+++ b/.github/workflows/socket-scan.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Run Socket scan
         # renovate: datasource=npm depName=socket

--- a/.github/workflows/socket-scan.yml
+++ b/.github/workflows/socket-scan.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Run Socket scan
         # renovate: datasource=npm depName=socket
-        run: npx socket@1.1.78 scan create --repo="$GITHUB_REPO" --branch="$GITHUB_BRANCH" --default-branch .
+        run: npx socket@1.1.78 scan create --repo="$GITHUB_REPO" --branch="$GITHUB_BRANCH" --default-branch --org=mazedesignhq .
         env:
           SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}
           GITHUB_REPO: ${{ github.repository }}

--- a/.github/workflows/socket-scan.yml
+++ b/.github/workflows/socket-scan.yml
@@ -27,5 +27,5 @@ jobs:
         run: npx socket@1.1.78 scan create --repo="$GITHUB_REPO" --branch="$GITHUB_BRANCH" --default-branch --org=mazedesignhq .
         env:
           SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}
-          GITHUB_REPO: ${{ github.repository }}
+          GITHUB_REPO: ${{ github.event.repository.name }}
           GITHUB_BRANCH: ${{ github.ref_name }}

--- a/.github/workflows/socket-scan.yml
+++ b/.github/workflows/socket-scan.yml
@@ -1,0 +1,25 @@
+name: Socket Security Scan
+
+on:
+  schedule:
+    - cron: '30 3 * * *' # daily at 3:30 AM UTC (offset from Coana at 3:00)
+  workflow_dispatch:
+
+jobs:
+  socket-security-scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 22
+
+      - name: Run Socket scan
+        run: npx socket@latest scan create --repo="${{ github.repository }}" --branch="${{ github.ref_name }}" --default-branch .
+        env:
+          SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}

--- a/.github/workflows/socket-scan.yml
+++ b/.github/workflows/socket-scan.yml
@@ -20,6 +20,7 @@ jobs:
           node-version: 22
 
       - name: Run Socket scan
-        run: npx socket@latest scan create --repo="${{ github.repository }}" --branch="${{ github.ref_name }}" --default-branch .
+        # renovate: datasource=npm depName=socket
+        run: npx socket@1.1.78 scan create --repo="${{ github.repository }}" --branch="${{ github.ref_name }}" --default-branch .
         env:
           SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}

--- a/.github/workflows/socket-scan.yml
+++ b/.github/workflows/socket-scan.yml
@@ -5,6 +5,9 @@ on:
     - cron: '30 3 * * *' # daily at 3:30 AM UTC (offset from Coana at 3:00)
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   socket-security-scan:
     runs-on: ubuntu-latest
@@ -21,6 +24,8 @@ jobs:
 
       - name: Run Socket scan
         # renovate: datasource=npm depName=socket
-        run: npx socket@1.1.78 scan create --repo="${{ github.repository }}" --branch="${{ github.ref_name }}" --default-branch .
+        run: npx socket@1.1.78 scan create --repo="$GITHUB_REPO" --branch="$GITHUB_BRANCH" --default-branch .
         env:
           SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}
+          GITHUB_REPO: ${{ github.repository }}
+          GITHUB_BRANCH: ${{ github.ref_name }}

--- a/socket.json
+++ b/socket.json
@@ -1,0 +1,16 @@
+{
+  " _____         _       _     ": "Local config file for Socket CLI tool ( https://socket.dev/npm/package/socket ), to work with https://socket.dev",
+  "|   __|___ ___| |_ ___| |_   ": "     The config in this file is used to set as defaults for flags or command args when using the CLI",
+  "|__   | . |  _| '_| -_|  _|  ": "     in this dir, often a repo root. You can choose commit or .ignore this file, both works.",
+  "|_____|___|___|_,_|___|_|.dev": "Warning: This file may be overwritten without warning by `socket manifest setup` or other commands",
+  "version": 1,
+  "defaults": {
+    "scan": {
+      "create": {
+        "repo": "heatmap.js",
+        "workspace": "mazedesignhq",
+        "branch": "main"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds daily Socket.dev dependency scan via `socket scan create` CLI
- Runs at 3:30 AM UTC on ubuntu-latest
- Uses org-level `SOCKET_SECURITY_API_KEY` secret

## Test plan
- [ ] Trigger workflow_dispatch to verify scan runs
- [ ] Check Socket dashboard for scan result

🤖 Generated with [Claude Code](https://claude.com/claude-code)