### PR TITLE
PLA-1049: Enable full reachability analysis in socket scan

### DIFF
--- a/.github/workflows/socket-scan.yml
+++ b/.github/workflows/socket-scan.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Run Socket scan
         # renovate: datasource=npm depName=socket
-        run: npx socket@1.1.78 scan create --repo="$GITHUB_REPO" --branch="$GITHUB_BRANCH" --default-branch --org=mazedesignhq .
+        run: npx socket@1.1.78 scan create --repo="$GITHUB_REPO" --branch="$GITHUB_BRANCH" --default-branch --org=mazedesignhq --reach .
         env:
           SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}
           GITHUB_REPO: ${{ github.event.repository.name }}


### PR DESCRIPTION
## Summary
- Adds `--reach` flag to `socket scan create` for full application reachability analysis
- Traces call graphs to determine whether CVEs in dependencies are actually reachable from application code
- https://docs.socket.dev/docs/full-application-reachability

## Test plan
- [ ] Trigger workflow_dispatch to verify scan runs with reachability
- [ ] Check Socket dashboard for reachability results

🤖 Generated with [Claude Code](https://claude.com/claude-code)