### PR TITLE
PLA-1049: Fix socket scan — enable corepack for pnpm

### DIFF
--- a/.github/workflows/socket-scan.yml
+++ b/.github/workflows/socket-scan.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           node-version: 24
 
+      - name: Enable corepack
+        run: corepack enable
+
       - name: Run Socket scan
         # renovate: datasource=npm depName=socket
         run: npx socket@1.1.78 scan create --repo="$GITHUB_REPO" --branch="$GITHUB_BRANCH" --default-branch --org=mazedesignhq --reach .


### PR DESCRIPTION
## Summary
- Adds `corepack enable` step so pnpm is available for reachability analysis
- Socket's `--reach` flag needs the package manager in PATH to analyze dependency graphs

## Test plan
- [ ] Trigger workflow_dispatch to verify scan completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)